### PR TITLE
support less modifyVars

### DIFF
--- a/lib/webpack.common.config.js
+++ b/lib/webpack.common.config.js
@@ -49,7 +49,7 @@ module.exports = {
         loader: ExtractTextPlugin.extract(
           'css?sourceMap!' +
           'autoprefixer-loader!' +
-          'less?{"modifyVars":' + JSON.stringify(pkg.theme || {})+'}'
+          'less?{"sourceMap":true,"modifyVars":' + JSON.stringify(pkg.theme || {})+'}'
         )
       },
       {test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: 'url?limit=10000&minetype=application/font-woff'},

--- a/lib/webpack.common.config.js
+++ b/lib/webpack.common.config.js
@@ -49,7 +49,7 @@ module.exports = {
         loader: ExtractTextPlugin.extract(
           'css?sourceMap!' +
           'autoprefixer-loader!' +
-          'less?sourceMap'
+          'less?{"modifyVars":' + JSON.stringify(pkg.theme || {})+'}'
         )
       },
       {test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: 'url?limit=10000&minetype=application/font-woff'},


### PR DESCRIPTION
reference: https://github.com/ant-design/ant-design/issues/384

通过 less-loader 的 modifyVars 支持项目单独配置 antd 的主色调。在项目 `package.json` 中配置：

```json
"theme": {
  "primary-color": "#6FC053"
}
```

需要 [antd](https://github.com/ant-design/ant-design) 进行配合改造，不使用编译后的 index.css，直接调用 `require('../style/index.less')` 才行。