### PR TITLE
bugfix: add webpack loader for images

### DIFF
--- a/lib/webpack.common.config.js
+++ b/lib/webpack.common.config.js
@@ -56,7 +56,8 @@ module.exports = {
       {test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, loader: 'url?limit=10000&minetype=application/font-woff'},
       {test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: 'url?limit=10000&minetype=application/octet-stream'},
       {test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: 'file'},
-      {test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: 'url?limit=10000&minetype=image/svg+xml'}
+      {test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: 'url?limit=10000&minetype=image/svg+xml'},
+      {test: /\.(png|jpg|jpeg|gif)(\?v=\d+\.\d+\.\d+)?$/i, loader: 'url?limit=10000'}
     ]
   },
 


### PR DESCRIPTION
reference: https://github.com/webpack/react-starter/blob/master/make-webpack-config.js#L22

code:

```less
.logo{
  width: @banner-width;
  height: @banner-height;
  .img-retina('../../asset/logo.png', '../../asset/logo@2x.png', @banner-width, @banner-height);
}
```

error:

```shell
ERROR in ./src/stylesheet/index.less
Module build failed: ModuleParseError: Module parse failed: /Users/liangwensen/repo/alibaba/fcdatalab/webroot/public/admin/src/asset/logo.png Line 1: Unexpected token ILLEGAL
You may need an appropriate loader to handle this file type.
(Source code omitted for this binary file)
    at DependenciesBlock.<anonymous> (/Users/liangwensen/.nvm/versions/node/v4.2.2/lib/node_modules/antd-build/node_modules/webpack/lib/NormalModule.js:113:20)
    at DependenciesBlock.onModuleBuild (/Users/liangwensen/.nvm/versions/node/v4.2.2/lib/node_modules/antd-build/node_modules/webpack/node_modules/webpack-core/lib/NormalModuleMixin.js:310:10)
    at nextLoader (/Users/liangwensen/.nvm/versions/node/v4.2.2/lib/node_modules/antd-build/node_modules/webpack/node_modules/webpack-core/lib/NormalModuleMixin.js:275:25)
    at /Users/liangwensen/.nvm/versions/node/v4.2.2/lib/node_modules/antd-build/node_modules/webpack/node_modules/webpack-core/lib/NormalModuleMixin.js:259:5
    at Storage.finished (/Users/liangwensen/.nvm/versions/node/v4.2.2/lib/node_modules/antd-build/node_modules/webpack/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:38:16)
    at /Users/liangwensen/.nvm/versions/node/v4.2.2/lib/node_modules/antd-build/node_modules/webpack/node_modules/enhanced-resolve/node_modules/graceful-fs/graceful-fs.js:76:16
    at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:380:3)
```